### PR TITLE
NPC network traffic fix

### DIFF
--- a/BunnyGame/Assets/Resources/Prefabs/TurtleNPC.prefab
+++ b/BunnyGame/Assets/Resources/Prefabs/TurtleNPC.prefab
@@ -227,7 +227,7 @@ GameObject:
   - component: {fileID: 114096059962507916}
   m_Layer: 14
   m_Name: TurtleNPC
-  m_TagString: Untagged
+  m_TagString: npc
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1425,12 +1425,12 @@ MonoBehaviour:
   m_Script: {fileID: -1768714887, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_TransformSyncMode: 4
+  m_TransformSyncMode: 1
   m_SendInterval: 1
-  m_SyncRotationAxis: 7
+  m_SyncRotationAxis: 2
   m_RotationSyncCompression: 0
   m_SyncSpin: 0
-  m_MovementTheshold: 0.001
+  m_MovementTheshold: 0.1
   m_VelocityThreshold: 0.0001
   m_SnapThreshold: 5
   m_InterpolateRotation: 1
@@ -1466,7 +1466,7 @@ MonoBehaviour:
     i14: 245
     i15: 176
   m_ServerOnly: 0
-  m_LocalPlayerAuthority: 1
+  m_LocalPlayerAuthority: 0
 --- !u!143 &143267633037588566
 CharacterController:
   m_ObjectHideFlags: 1

--- a/BunnyGame/Assets/Scenes/Island.unity
+++ b/BunnyGame/Assets/Scenes/Island.unity
@@ -16014,7 +16014,7 @@ MonoBehaviour:
     i13: 0
     i14: 0
     i15: 0
-  m_ServerOnly: 1
+  m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
 --- !u!114 &1416740662
 MonoBehaviour:

--- a/BunnyGame/Assets/Scenes/Lobby.unity
+++ b/BunnyGame/Assets/Scenes/Lobby.unity
@@ -845,7 +845,7 @@ MonoBehaviour:
   m_RunInBackground: 1
   m_ScriptCRCCheck: 1
   m_MaxDelay: 0.01
-  m_LogLevel: 4
+  m_LogLevel: 1
   m_PlayerPrefab: {fileID: 0}
   m_AutoCreatePlayer: 1
   m_PlayerSpawnMethod: 0

--- a/BunnyGame/Assets/Scripts/NPC/NPC.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPC.cs
@@ -5,9 +5,10 @@ using UnityEngine.Networking;
 
 // All of the logic for the NPC will be handeled by NPCThread
 public class NPC : NetworkBehaviour {
-    [SyncVar(hook = "spawn")]
+    [SyncVar(hook = "spawnPos")]
     private Vector3 _spawnPos;
-    [SyncVar]
+    [SyncVar(hook = "spawnRot")]
+    private Quaternion _spawnRot;
     private Vector3 _moveDir;
     private CharacterController _cc;
     private GameObject _blood;
@@ -29,12 +30,21 @@ public class NPC : NetworkBehaviour {
         this.transform.LookAt(transform.position + this._moveDir);
 	}
 
-    public void spawn(Vector3 _spawnPos) {
+    public void spawnPos(Vector3 _spawnPos) {
         transform.position = _spawnPos;
+    }
+
+    public void spawnRot(Quaternion _spawnRot) {
+        transform.rotation = _spawnRot;
     }
 
     public void setSpawnPos(Vector3 spawnPos) {
         this._spawnPos = spawnPos;
+        this._moveDir = this.transform.forward;
+    }
+
+    public void setSpawnRot(Quaternion spawnRot) {
+        this._spawnRot = spawnRot;
     }
 
     public void setMoveDir(Vector3 moveDir) {

--- a/BunnyGame/Assets/Scripts/NPC/NPCThread.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCThread.cs
@@ -41,7 +41,7 @@ public class NPCThread {
 	public NPCThread (BlockingQueue<instruction> i) {
         this._thread = new Thread(new ThreadStart(threadRunner)); //This starts running the update function
         this._instructions = i;
-        _rng = new System.Random();
+        this._rng = new System.Random(691337);
 
         this._npcStates = new Dictionary<int, NPCState>();
         var npcs = NPCWorldView.getNpcs();
@@ -83,8 +83,9 @@ public class NPCThread {
                         fleeDir = this.avoidPlayer(npc, player);
                         this.sendInstuction(npc, fleeDir.normalized * speed);
                     } else if (state.contains(State.ROAMING)) {
-                        roamDir = this.randomDir(npc);
-                        if (roamDir != Vector3.zero) this.sendInstuction(npc, roamDir.normalized * speed);
+                        //This thing goes out of sync real fast
+                        //roamDir = this.randomDir(npc);
+                        //if (roamDir != Vector3.zero) this.sendInstuction(npc, roamDir.normalized * speed);
                     }
                     npc.update(npc.getPos() + npc.getDir() * (1 / 60),  npc.getDir()); // Try to guess next pos
                 }

--- a/BunnyGame/Assets/Scripts/NetworkPlayerSelect.cs
+++ b/BunnyGame/Assets/Scripts/NetworkPlayerSelect.cs
@@ -85,4 +85,14 @@ public class NetworkPlayerSelect : NetworkLobbyManager {
         else
             this._selections[clientID] = model;
     }
+
+    public virtual void OnServerDisconnect(NetworkConnection conn) {
+        NetworkServer.DestroyPlayersForConnection(conn);
+        if (conn.lastError != NetworkError.Ok) {
+            if (LogFilter.logError) {
+                Debug.LogError("ServerDisconnected due to error: " + conn.lastError);
+            }
+        }
+    }
+
 }

--- a/BunnyGame/ProjectSettings/TagManager.asset
+++ b/BunnyGame/ProjectSettings/TagManager.asset
@@ -9,6 +9,7 @@ TagManager:
   - Enemy
   - foxbite
   - ground
+  - npc
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
- NPCs now use less network traffic, server was sending about 2KB/s with laptop as client.
- Every client now runs their own NPC thread, turtles sync their transform with the server every 1 sec, can look wonky.
- Testet with desktop and laptop in an online match, they made it past the 2 min mark without getting disconnected. 