### PR TITLE
Improvements to the movement sound

### DIFF
--- a/BunnyGame/Assets/Resources/Prefabs/Players/PlayerCharacterBird.prefab
+++ b/BunnyGame/Assets/Resources/Prefabs/Players/PlayerCharacterBird.prefab
@@ -779,8 +779,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animalSound: {fileID: 0}
-  footStepFrequency: 0.5
-  runSpeedFrequency: 0.2
+  frequencyModifier: 0.5
+  distanceFromGroundToCenter: 0.9
 --- !u!114 &114338138868947958
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/BunnyGame/Assets/Resources/Prefabs/Players/PlayerCharacterBunny.prefab
+++ b/BunnyGame/Assets/Resources/Prefabs/Players/PlayerCharacterBunny.prefab
@@ -1344,8 +1344,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animalSound: {fileID: 0}
-  footStepFrequency: 1.3
-  runSpeedFrequency: 0.5
+  frequencyModifier: 1.3
+  distanceFromGroundToCenter: 0.73
 --- !u!114 &114961053703169034
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/BunnyGame/Assets/Resources/Prefabs/Players/PlayerCharacterFox.prefab
+++ b/BunnyGame/Assets/Resources/Prefabs/Players/PlayerCharacterFox.prefab
@@ -1100,8 +1100,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animalSound: {fileID: 0}
-  footStepFrequency: 0.4
-  runSpeedFrequency: 0.2
+  frequencyModifier: 0.4
+  distanceFromGroundToCenter: 2
 --- !u!114 &114831858758883044
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/BunnyGame/Assets/Resources/Prefabs/Players/PlayerCharacterMoose.prefab
+++ b/BunnyGame/Assets/Resources/Prefabs/Players/PlayerCharacterMoose.prefab
@@ -881,8 +881,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animalSound: {fileID: 0}
-  footStepFrequency: 0.4
-  runSpeedFrequency: 0.2
+  frequencyModifier: 0.4
+  distanceFromGroundToCenter: 1.6
 --- !u!114 &114246946153738920
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/BunnyGame/Assets/Scenes/etc.meta
+++ b/BunnyGame/Assets/Scenes/etc.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: c2017708e399fc14694a106a0481b711
-folderAsset: yes
-timeCreated: 1508320807
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BunnyGame/Assets/Scripts/Abilities/AbilityNetwork.cs
+++ b/BunnyGame/Assets/Scripts/Abilities/AbilityNetwork.cs
@@ -44,10 +44,10 @@ public class AbilityNetwork : NetworkBehaviour {
 
     private IEnumerator stealth(float activeTime,float transparancy, float volumeMod)
     {
-        GetComponent<PlayerAudio>().updateVolumeModifier(volumeMod);
+        GetComponent<PlayerAudio>().updateVolume(volumeModifier: volumeMod);
         RpcSetTransparentFox(transparancy);
         yield return new WaitForSeconds(activeTime);
-        GetComponent<PlayerAudio>().updateVolumeModifier(1);
+        GetComponent<PlayerAudio>().updateVolume(volumeModifier: 1);
         RpcSetOrginalFox();
     }
 

--- a/BunnyGame/Assets/Scripts/Abilities/AbilityNetwork.cs
+++ b/BunnyGame/Assets/Scripts/Abilities/AbilityNetwork.cs
@@ -30,22 +30,24 @@ public class AbilityNetwork : NetworkBehaviour {
 
     ///////////// Functions for Stealth ability /////////////////
 
-    public void useStealth(int modelChildNum, float activeTime, float transparancy)
+    public void useStealth(int modelChildNum, float activeTime, float transparancy, float volumeMod)
     {
         this.modelChildNum = modelChildNum;
-        CmdStealth(activeTime, transparancy);
+        CmdStealth(activeTime, transparancy, volumeMod);
     }
     
     [Command]
-    public void CmdStealth(float activeTime, float transparancy)
+    public void CmdStealth(float activeTime, float transparancy, float volumeMod)
     {
-        StartCoroutine(stealth(activeTime,transparancy));
+        StartCoroutine(stealth(activeTime,transparancy, volumeMod));
     }
 
-    private IEnumerator stealth(float activeTime,float transparancy)
+    private IEnumerator stealth(float activeTime,float transparancy, float volumeMod)
     {
+        GetComponent<PlayerAudio>().updateVolumeModifier(volumeMod);
         RpcSetTransparentFox(transparancy);
         yield return new WaitForSeconds(activeTime);
+        GetComponent<PlayerAudio>().updateVolumeModifier(1);
         RpcSetOrginalFox();
     }
 

--- a/BunnyGame/Assets/Scripts/Abilities/Stealth.cs
+++ b/BunnyGame/Assets/Scripts/Abilities/Stealth.cs
@@ -10,6 +10,7 @@ public class Stealth : SpecialAbility {
 
     private float _stealthActive = 10.0f;
     private float _transparency = 0.1f;
+    private float _stealthSoundLevel = 0.1f;
     private int _modelChildNum = 1;
 
     AbilityNetwork networkAbility;
@@ -30,6 +31,6 @@ public class Stealth : SpecialAbility {
 
         StartCoroutine(base.doCoolDown());
 
-        networkAbility.useStealth(this._modelChildNum,this._stealthActive, this._transparency);
+        networkAbility.useStealth(this._modelChildNum,this._stealthActive, this._transparency, this._stealthSoundLevel);
     }
 }

--- a/BunnyGame/Assets/Scripts/Player/PlayerAudio.cs
+++ b/BunnyGame/Assets/Scripts/Player/PlayerAudio.cs
@@ -24,7 +24,7 @@ public class PlayerAudio : MonoBehaviour {
 
     void Awake() {
         _movementPlayer = gameObject.AddComponent<AudioSource>();
-        _movementPlayer.volume = 0;
+        //_movementPlayer.volume = 0;
         _movementPlayer.rolloffMode = AudioRolloffMode.Linear;
         _movementPlayer.minDistance = 0;
         _movementPlayer.maxDistance = 50;
@@ -34,13 +34,13 @@ public class PlayerAudio : MonoBehaviour {
 
 
         _animalSoundPlayer = gameObject.AddComponent<AudioSource>();
-        _animalSoundPlayer.clip = animalSound;
-        _animalSoundPlayer.volume = 0;
-        _animalSoundPlayer.rolloffMode = AudioRolloffMode.Linear;
-        _animalSoundPlayer.minDistance = 0;
-        _animalSoundPlayer.maxDistance = 50;
-        _animalSoundPlayer.spatialBlend = 1;
-        _animalSoundPlayer.spatialize = true;
+        //_animalSoundPlayer.clip = animalSound;
+        //_animalSoundPlayer.volume = 0;
+        //_animalSoundPlayer.rolloffMode = AudioRolloffMode.Linear;
+        //_animalSoundPlayer.minDistance = 0;
+        //_animalSoundPlayer.maxDistance = 50;
+        //_animalSoundPlayer.spatialBlend = 1;
+        //_animalSoundPlayer.spatialize = true;
     }
 
     void Start () {
@@ -116,13 +116,13 @@ public class PlayerAudio : MonoBehaviour {
 
     private IEnumerator playFootSteps() {
         RaycastHit hit = new RaycastHit();
+        float normalSpeed = _playerController.walkSpeed;
         while (true) {
             Physics.Raycast(transform.position, Vector3.down, out hit);
-            bool isGrounded = hit.distance < this.distanceFromGroundToCenter;
-            Debug.Log(isGrounded + " " + hit.distance);
-            if (isGrounded && _playerController.currentSpeed > 1) {
+            if (hit.distance < this.distanceFromGroundToCenter && _characterController.velocity.magnitude > 1) {
                 _movementPlayer.PlayOneShot(_footStepClips[_currentGroundType]);
-                float time = Mathf.Min(1, _playerController.walkSpeed/_playerController.currentSpeed) * this.frequencyModifier;
+                float time = Mathf.Clamp(normalSpeed / _characterController.velocity.magnitude, 0.3f, 1) * this.frequencyModifier;
+                Debug.Log(GetComponent<PlayerInformation>().playerName + " : " + normalSpeed / _playerController.currentSpeed);
                 yield return new WaitForSeconds(time);
             }
             else yield return null;

--- a/BunnyGame/Assets/Scripts/Player/PlayerAudio.cs
+++ b/BunnyGame/Assets/Scripts/Player/PlayerAudio.cs
@@ -16,31 +16,30 @@ public class PlayerAudio : MonoBehaviour {
     // Movement
     private AudioSource _movementPlayer;
     private string _currentGroundType;
-    public float frequencyModifier = 1;
+    public float frequencyModifier = 1; // This is for matching the frequency with the animation
     public float distanceFromGroundToCenter = 1f;
+    public float volumeModifier = 1f;
     private Dictionary<string, AudioClip> _footStepClips  = new Dictionary<string, AudioClip>();
     private Dictionary<string, AudioClip> _groundHitClips = new Dictionary<string, AudioClip>();
     
 
     void Awake() {
         _movementPlayer = gameObject.AddComponent<AudioSource>();
-        //_movementPlayer.volume = 0;
-        _movementPlayer.rolloffMode = AudioRolloffMode.Linear;
-        _movementPlayer.minDistance = 0;
-        _movementPlayer.maxDistance = 50;
-        _movementPlayer.spatialBlend = 1;
+        _movementPlayer.rolloffMode  = AudioRolloffMode.Linear;
+        _movementPlayer.minDistance  =  0;
+        _movementPlayer.maxDistance  = 50;
+        _movementPlayer.spatialBlend =  1;
         _movementPlayer.spatialize = true;
 
 
 
         _animalSoundPlayer = gameObject.AddComponent<AudioSource>();
         //_animalSoundPlayer.clip = animalSound;
-        //_animalSoundPlayer.volume = 0;
         //_animalSoundPlayer.rolloffMode = AudioRolloffMode.Linear;
-        //_animalSoundPlayer.minDistance = 0;
-        //_animalSoundPlayer.maxDistance = 50;
+        //_animalSoundPlayer.minDistance  = 0;
+        //_animalSoundPlayer.maxDistance  = 50;
         //_animalSoundPlayer.spatialBlend = 1;
-        //_animalSoundPlayer.spatialize = true;
+        //_animalSoundPlayer.spatialize   = true;
     }
 
     void Start () {
@@ -50,12 +49,12 @@ public class PlayerAudio : MonoBehaviour {
 
 
         foreach (string name in new string[] { "leaf", "dirt", "stone", "wood" }) {
-            _footStepClips.Add(name, Resources.Load<AudioClip>("Audio/Movement/" + name));
+            _footStepClips.Add(name,  Resources.Load<AudioClip>("Audio/Movement/" + name));
             _groundHitClips.Add(name, Resources.Load<AudioClip>("Audio/GroundHit/" + name));
         }
 
 
-        updateVolume(PlayerPrefs.GetFloat("Effect Volume", 100) / 100f * (PlayerPrefs.GetFloat("Master Volume", 100) / 100f));
+        updateVolume();
 
         StartCoroutine(playFootSteps());
     }
@@ -65,13 +64,20 @@ public class PlayerAudio : MonoBehaviour {
         if(newGroundType != _currentGroundType && newGroundType != "") {
             _currentGroundType = newGroundType;
         }
-
 	}
 
     public void updateVolume(float v) {
         _volume = v;
         _movementPlayer.volume = v;
         _animalSoundPlayer.volume = v;
+    }
+
+    public void updateVolume() {
+        updateVolume(PlayerPrefs.GetFloat("Effect Volume", 100) / 100f * (PlayerPrefs.GetFloat("Master Volume", 100) / 100f) * volumeModifier);
+    }
+
+    public void updateVolumeModifier(float volumeMod) {
+        updateVolume(PlayerPrefs.GetFloat("Effect Volume", 100) / 100f * (PlayerPrefs.GetFloat("Master Volume", 100) / 100f) * volumeMod);
     }
 
     public float getVolume() {

--- a/BunnyGame/Assets/Scripts/Player/PlayerAudio.cs
+++ b/BunnyGame/Assets/Scripts/Player/PlayerAudio.cs
@@ -99,9 +99,8 @@ public class PlayerAudio : MonoBehaviour {
                 case "mat17":
                     return "stone";
                 case "mat18": // !! This is because the big mountain is in the same mesh as the ground... so I have to manually check whether it is stone or dirt...
-                    Debug.Log(transform.position + "; dist:" + Vector3.Distance(transform.position, new Vector3(24, transform.position.y, 44)));
                     if (transform.position.y > -12.5f && Vector3.Distance(transform.position, new Vector3(24,transform.position.y,44)) < 80)
-                        return "stone";
+                         return "stone";
                     else return "dirt";
                 case "mat20":
                     return "wood";
@@ -114,8 +113,11 @@ public class PlayerAudio : MonoBehaviour {
 
 
     private IEnumerator playFootSteps() {
+        Ray ray = new Ray(transform.position, Vector3.down);
+
         while (true) {
-            if (_characterController.isGrounded && _characterController.velocity.magnitude > 0.1f) {
+            Debug.Log(Physics.Raycast(ray, 0.2f) + " : " + _characterController.velocity.magnitude);
+            if (Physics.Raycast(ray, 0.2f) && _characterController.velocity.magnitude > 0.1f) {
                 _movementPlayer.PlayOneShot(_footStepClips[_currentGroundType]);
                 yield return new WaitForSeconds(_playerController.running ? runSpeedFrequency : footStepFrequency);
             }


### PR DESCRIPTION
The movement sound now plays at the correct frequency for other players than yourself. 
It scales automatically based on how fast you're going in relation to base speed (previously there was a hardcoded frequency for walking and running, which made the frequency wrong if using a Sprint ability)

When using the stealth ability, the player makes less sound.

There does seem to be a slight delay on the sound, this isn't noticable at low speeds, but can become noticable when using the fox' sprint ability.