### PR TITLE
Fix for issue #122

### DIFF
--- a/BunnyGame/Assets/Resources/Prefabs/NPCManager.prefab
+++ b/BunnyGame/Assets/Resources/Prefabs/NPCManager.prefab
@@ -1,0 +1,284 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1251516565716470}
+  m_IsPrefabParent: 1
+--- !u!1 &1015970561649926
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4437783978001508}
+  m_Layer: 0
+  m_Name: DifficultSpot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1168361003455666
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4561842773249256}
+  m_Layer: 0
+  m_Name: LakePos
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1249994539581116
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4415590440194116}
+  m_Layer: 0
+  m_Name: DifficultSpot 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1251516565716470
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4959806735303006}
+  - component: {fileID: 114023548694583208}
+  - component: {fileID: 114684915946104982}
+  - component: {fileID: 114392278232915640}
+  m_Layer: 0
+  m_Name: NPCManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1277879895639200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4058483966942732}
+  m_Layer: 0
+  m_Name: OceanPos
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1499512076253140
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4444402438968868}
+  m_Layer: 0
+  m_Name: LandPos
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1613430659524060
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4490124764938036}
+  m_Layer: 0
+  m_Name: RiverPos
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4058483966942732
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1277879895639200}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -122.44, y: -18.67, z: -114.14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4959806735303006}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4415590440194116
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1249994539581116}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -59.59, y: -18.91, z: 68.32}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4959806735303006}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4437783978001508
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1015970561649926}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -107.44, y: -18.91, z: 49.21}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4959806735303006}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4444402438968868
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1499512076253140}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7.61, y: -16.32, z: -28.49}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4959806735303006}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4490124764938036
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1613430659524060}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 56.23, y: -18.86, z: -78.8}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4959806735303006}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4561842773249256
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1168361003455666}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -57.41, y: -18.84, z: 12.95}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4959806735303006}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4959806735303006
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1251516565716470}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4561842773249256}
+  - {fileID: 4490124764938036}
+  - {fileID: 4058483966942732}
+  - {fileID: 4444402438968868}
+  - {fileID: 4437783978001508}
+  - {fileID: 4415590440194116}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114023548694583208
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1251516565716470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1696758b75d90d4419b0e3e96fc5fb9f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114392278232915640
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1251516565716470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 061a4f0739a459d449c9c5f6a084bcc9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debugRenderLand: 0
+  debugRenderWater: 0
+  waterBodies:
+  - {fileID: 4058483966942732}
+  - {fileID: 4561842773249256}
+  - {fileID: 4490124764938036}
+  difficultSpots:
+  - {fileID: 4437783978001508}
+  - {fileID: 4415590440194116}
+  landPos: {fileID: 4444402438968868}
+  progressBar: {fileID: 0}
+  progressUI: {fileID: 0}
+--- !u!114 &114684915946104982
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1251516565716470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 372142912, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SceneId:
+    m_Value: 0
+  m_AssetId:
+    i0: 26
+    i1: 37
+    i2: 197
+    i3: 237
+    i4: 89
+    i5: 90
+    i6: 208
+    i7: 196
+    i8: 90
+    i9: 213
+    i10: 108
+    i11: 244
+    i12: 105
+    i13: 46
+    i14: 179
+    i15: 180
+  m_ServerOnly: 0
+  m_LocalPlayerAuthority: 0

--- a/BunnyGame/Assets/Resources/Prefabs/NPCManager.prefab.meta
+++ b/BunnyGame/Assets/Resources/Prefabs/NPCManager.prefab.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1a25c5ed595ad0c45ad56cf4692eb3b4
+timeCreated: 1509214478
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BunnyGame/Assets/Scenes/Island.unity
+++ b/BunnyGame/Assets/Scenes/Island.unity
@@ -309,12 +309,12 @@ Prefab:
     - target: {fileID: 224625647126962944, guid: 46fd08022e0481a4db71539919f7d1eb,
         type: 2}
       propertyPath: m_LocalPosition.x
-      value: 568.5
+      value: 668
       objectReference: {fileID: 0}
     - target: {fileID: 224625647126962944, guid: 46fd08022e0481a4db71539919f7d1eb,
         type: 2}
       propertyPath: m_LocalPosition.y
-      value: 321.5
+      value: 339
       objectReference: {fileID: 0}
     - target: {fileID: 224625647126962944, guid: 46fd08022e0481a4db71539919f7d1eb,
         type: 2}
@@ -344,7 +344,7 @@ Prefab:
     - target: {fileID: 224625647126962944, guid: 46fd08022e0481a4db71539919f7d1eb,
         type: 2}
       propertyPath: m_RootOrder
-      value: 15
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 224625647126962944, guid: 46fd08022e0481a4db71539919f7d1eb,
         type: 2}
@@ -746,34 +746,6 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 13b31f15cbfe54e98a0831fe33138673, type: 2}
   m_IsPrefabParent: 0
---- !u!1 &300723627
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 300723628}
-  m_Layer: 0
-  m_Name: DifficultSpot 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &300723628
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 300723627}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -59.59, y: -18.91, z: 68.32}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1416740660}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &303632156
 GameObject:
   m_ObjectHideFlags: 0
@@ -885,7 +857,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 376393139}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 548.5, y: 241.5, z: 0}
+  m_LocalPosition: {x: 648, y: 259, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1353435133}
@@ -1475,7 +1447,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 530150810}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 341.375, y: -156.125, z: 0}
+  m_LocalPosition: {x: 416, y: -169.25, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1256685111}
@@ -1676,34 +1648,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &605218569
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 605218570}
-  m_Layer: 0
-  m_Name: LandPos
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &605218570
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 605218569}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7.61, y: -16.32, z: -28.49}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1416740660}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &638441716
 GameObject:
   m_ObjectHideFlags: 0
@@ -1782,12 +1726,12 @@ Prefab:
     - target: {fileID: 224647576811944834, guid: 5a82466091efcfb47860fc93a946479c,
         type: 2}
       propertyPath: m_LocalPosition.x
-      value: 568.5
+      value: 668
       objectReference: {fileID: 0}
     - target: {fileID: 224647576811944834, guid: 5a82466091efcfb47860fc93a946479c,
         type: 2}
       propertyPath: m_LocalPosition.y
-      value: 321.5
+      value: 339
       objectReference: {fileID: 0}
     - target: {fileID: 224647576811944834, guid: 5a82466091efcfb47860fc93a946479c,
         type: 2}
@@ -1817,7 +1761,7 @@ Prefab:
     - target: {fileID: 224647576811944834, guid: 5a82466091efcfb47860fc93a946479c,
         type: 2}
       propertyPath: m_RootOrder
-      value: 16
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 224647576811944834, guid: 5a82466091efcfb47860fc93a946479c,
         type: 2}
@@ -2083,7 +2027,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4169717367129502, guid: 862f35bdd98f8794db225cec45bc86ee, type: 2}
       propertyPath: m_RootOrder
-      value: 17
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 114269071942134722, guid: 862f35bdd98f8794db225cec45bc86ee,
         type: 2}
@@ -2160,7 +2104,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 689247714}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 121.125, z: 0}
+  m_LocalPosition: {x: 0, y: 134.25, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1483854630}
@@ -2468,7 +2412,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 735544049}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 476, y: -94.2, z: 0}
+  m_LocalPosition: {x: 575.5, y: -94.2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 638441717}
@@ -2927,7 +2871,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 921211071}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -368.5, y: -171.5, z: 0}
+  m_LocalPosition: {x: -468, y: -189, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 37141592}
@@ -4023,7 +3967,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1353435129}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 568.5, y: 321.5, z: 0}
+  m_LocalPosition: {x: 668, y: 339, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1038108915}
@@ -4046,109 +3990,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!1 &1416740658
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1416740660}
-  - component: {fileID: 1416740659}
-  - component: {fileID: 1416740661}
-  - component: {fileID: 1416740662}
-  m_Layer: 0
-  m_Name: NPCManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1416740659
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1416740658}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1696758b75d90d4419b0e3e96fc5fb9f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &1416740660
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1416740658}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1544903129}
-  - {fileID: 2119927145}
-  - {fileID: 1804566619}
-  - {fileID: 605218570}
-  - {fileID: 1914326507}
-  - {fileID: 300723628}
-  m_Father: {fileID: 0}
-  m_RootOrder: 14
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1416740661
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1416740658}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 372142912, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SceneId:
-    m_Value: 0
-  m_AssetId:
-    i0: 0
-    i1: 0
-    i2: 0
-    i3: 0
-    i4: 0
-    i5: 0
-    i6: 0
-    i7: 0
-    i8: 0
-    i9: 0
-    i10: 0
-    i11: 0
-    i12: 0
-    i13: 0
-    i14: 0
-    i15: 0
-  m_ServerOnly: 0
-  m_LocalPlayerAuthority: 0
---- !u!114 &1416740662
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1416740658}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 061a4f0739a459d449c9c5f6a084bcc9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  debugRenderLand: 0
-  debugRenderWater: 0
-  waterBodies:
-  - {fileID: 1804566619}
-  - {fileID: 1544903129}
-  - {fileID: 2119927145}
-  difficultSpots:
-  - {fileID: 1914326507}
-  - {fileID: 300723628}
-  landPos: {fileID: 605218570}
-  progressBar: {fileID: 2099706221}
-  progressUI: {fileID: 1996341533}
 --- !u!1 &1481928740
 GameObject:
   m_ObjectHideFlags: 0
@@ -4298,7 +4139,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1483854626}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 568.5, y: 321.5, z: 0}
+  m_LocalPosition: {x: 668, y: 339, z: 0}
   m_LocalScale: {x: 1.3333334, y: 1.3333334, z: 1.3333334}
   m_Children:
   - {fileID: 530150811}
@@ -4469,34 +4310,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1487640077}
   m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1544903128
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1544903129}
-  m_Layer: 0
-  m_Name: LakePos
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1544903129
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1544903128}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -57.41, y: -18.84, z: 12.95}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1416740660}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1559490755
 GameObject:
@@ -5338,34 +5151,6 @@ Transform:
   m_PrefabParentObject: {fileID: 4859065738777746, guid: 759359c6626f7443786cbfe68f1b25f9,
     type: 2}
   m_PrefabInternal: {fileID: 1799413650}
---- !u!1 &1804566618
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1804566619}
-  m_Layer: 0
-  m_Name: OceanPos
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1804566619
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1804566618}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -122.44, y: -18.67, z: -114.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1416740660}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1809991305
 GameObject:
   m_ObjectHideFlags: 0
@@ -5515,7 +5300,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1810361967}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 548.5, y: 306.5, z: 0}
+  m_LocalPosition: {x: 648, y: 324, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1353435133}
@@ -5608,7 +5393,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1843381381}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -231.5, z: 0}
+  m_LocalPosition: {x: 0, y: -249, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1082943965}
@@ -6021,34 +5806,6 @@ Transform:
   m_Father: {fileID: 13853815}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1914326506
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1914326507}
-  m_Layer: 0
-  m_Name: DifficultSpot
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1914326507
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1914326506}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -107.44, y: -18.91, z: 49.21}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1416740660}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1942151578
 GameObject:
   m_ObjectHideFlags: 0
@@ -6074,7 +5831,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1942151578}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -241.125, z: 0}
+  m_LocalPosition: {x: 0, y: -254.25, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1483854630}
@@ -6451,12 +6208,12 @@ Prefab:
     - target: {fileID: 224179119851607162, guid: b7e67c082227a8944a47ad90efae0e89,
         type: 2}
       propertyPath: m_LocalPosition.x
-      value: 568.5
+      value: 668
       objectReference: {fileID: 0}
     - target: {fileID: 224179119851607162, guid: b7e67c082227a8944a47ad90efae0e89,
         type: 2}
       propertyPath: m_LocalPosition.y
-      value: 321.5
+      value: 339
       objectReference: {fileID: 0}
     - target: {fileID: 224179119851607162, guid: b7e67c082227a8944a47ad90efae0e89,
         type: 2}
@@ -6704,34 +6461,6 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2099706220}
---- !u!1 &2119927144
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 2119927145}
-  m_Layer: 0
-  m_Name: RiverPos
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2119927145
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2119927144}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 56.23, y: -18.86, z: -78.8}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1416740660}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2122040641
 GameObject:
   m_ObjectHideFlags: 0

--- a/BunnyGame/Assets/Scenes/Lobby.unity
+++ b/BunnyGame/Assets/Scenes/Lobby.unity
@@ -488,6 +488,7 @@ MonoBehaviour:
   - {fileID: 1371219469558158, guid: 7868255b01f08f74ba477c87e1f17596, type: 2}
   - {fileID: 1616204860125768, guid: 7be9ad9206dc56b4abdbdd270da2fbd7, type: 2}
   - {fileID: 1821135780120678, guid: e401706bb86e2664192b693d66285355, type: 2}
+  - {fileID: 1251516565716470, guid: 1a25c5ed595ad0c45ad56cf4692eb3b4, type: 2}
   m_CustomConfig: 0
   m_MaxConnections: 4
   m_ConnectionConfig:
@@ -564,12 +565,12 @@ Prefab:
     - target: {fileID: 224504343465629732, guid: 7855c7e2a48e7c04fa48ac93a1718de3,
         type: 2}
       propertyPath: m_LocalPosition.x
-      value: 568.5
+      value: 668
       objectReference: {fileID: 0}
     - target: {fileID: 224504343465629732, guid: 7855c7e2a48e7c04fa48ac93a1718de3,
         type: 2}
       propertyPath: m_LocalPosition.y
-      value: 320
+      value: 339
       objectReference: {fileID: 0}
     - target: {fileID: 224504343465629732, guid: 7855c7e2a48e7c04fa48ac93a1718de3,
         type: 2}

--- a/BunnyGame/Assets/Scenes/etc.meta
+++ b/BunnyGame/Assets/Scenes/etc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c2017708e399fc14694a106a0481b711
+folderAsset: yes
+timeCreated: 1508320807
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BunnyGame/Assets/Scripts/NPC/NPCBrain.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCBrain.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class NPCBrain { 
     //==============Member variables==================================================
     private Stack<State>                            _state;
-    private NPCWorldView.GameCharacter              _npc;
+    public NPCWorldView.GameCharacter              _npc;
     private BlockingQueue<NPCThread.instruction>    _instructions;
     private float                                   _speed;
 

--- a/BunnyGame/Assets/Scripts/NPC/NPCManager.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCManager.cs
@@ -27,6 +27,7 @@ public class NPCManager : NetworkBehaviour {
         this._ready = false;
         if (this.isServer) StartCoroutine(waitForClients());
         StartCoroutine(init());
+        Debug.Log(this._playerCount);
     }
 
     //Waits for clients, then syncs playercount, and spawns npcs
@@ -57,13 +58,13 @@ public class NPCManager : NetworkBehaviour {
     //The NPCThread uses a thread safe representation of the World provided by NPCWorldView.
     private IEnumerator init() {
         while (!NPCWorldView.ready) yield return 0;
-        while (this._playerCount == -1) yield return 0;
+
+        //Wait for all NPCs to spawn
+        while (GameObject.FindGameObjectsWithTag("npc").Length != 100)
+            yield return 0;
 
         //Wait for all players to spawn, +1 for localplayer 
         while (this._playerCount != (GameObject.FindGameObjectsWithTag("Enemy").Length + 1))
-            yield return 0;
-        //Wait for all NPCs to spawn
-        while (GameObject.FindGameObjectsWithTag("npc").Length != 100)
             yield return 0;
 
         //gather data about players for the NPCs

--- a/BunnyGame/Assets/Scripts/NPC/NPCManager.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCManager.cs
@@ -4,21 +4,20 @@ using UnityEngine;
 using UnityEngine.Networking;
 
 public class NPCManager : NetworkBehaviour {
-    [SyncVar(hook ="setPlayerCount")]
-    private int _playerCount;
+    [SyncVar]
+    private int _playerCount = -1;
     private int _cellCount; //Amount of cells in NPCWorldView
 
-    private Dictionary<int, GameObject>             _players;       //Used to update NPCWorldView
-    private Dictionary<int, GameObject>             _npcs;          //Used to update NPCWorldView
-    private List<int>                               _deadPlayers;   //Keeps track of dead players, so that they can be removed from datastructures at a convenient time
-    private List<int>                               _deadNpcs;      //Keeps track of dead npcs, so that they can be removed from datastructures at a convenient time
-    private NPCThread                               _npcThread;     //The thread running the logic for NPCs using NPCWorldView maintained by this class
-    private BlockingQueue<NPCThread.instruction>    _instructions;  //Queue used to recieve instuctions from NPCThread
-    private bool                                    _ready;         //Flag set to true when initialization is finished
+    private Dictionary<int, GameObject> _players;       //Used to update NPCWorldView
+    private Dictionary<int, GameObject> _npcs;          //Used to update NPCWorldView
+    private List<int> _deadPlayers;   //Keeps track of dead players, so that they can be removed from datastructures at a convenient time
+    private List<int> _deadNpcs;      //Keeps track of dead npcs, so that they can be removed from datastructures at a convenient time
+    private NPCThread _npcThread;     //The thread running the logic for NPCs using NPCWorldView maintained by this class
+    private BlockingQueue<NPCThread.instruction> _instructions;  //Queue used to recieve instuctions from NPCThread
+    private bool _ready;         //Flag set to true when initialization is finished
 
     // Use this for initialization
     void Start() {
-        this._playerCount = -1;
         _cellCount = NPCWorldView.cellCount;
 
         this._players = new Dictionary<int, GameObject>();
@@ -28,10 +27,6 @@ public class NPCManager : NetworkBehaviour {
         this._ready = false;
         if (this.isServer) StartCoroutine(waitForClients());
         StartCoroutine(init());
-    }
-
-    private void setPlayerCount(int count) {
-        this._playerCount = count;
     }
 
     //Waits for clients, then syncs playercount, and spawns npcs
@@ -52,7 +47,6 @@ public class NPCManager : NetworkBehaviour {
 
             this._playerCount = playerCount; //sync playerCount to clients, now that all are here
         }
-
     }
 
     //Spawn NPCs, then register players/npcs in datastructures in this class, and NPCWorldView
@@ -62,6 +56,7 @@ public class NPCManager : NetworkBehaviour {
     //The need for keeping two list comes from the fact that the Unity API is not thread safe.
     //The NPCThread uses a thread safe representation of the World provided by NPCWorldView.
     private IEnumerator init() {
+        while (!NPCWorldView.ready) yield return 0;
         while (this._playerCount == -1) yield return 0;
 
         //Wait for all players to spawn, +1 for localplayer 
@@ -97,7 +92,7 @@ public class NPCManager : NetworkBehaviour {
     }
 
     // Update is called once per frame
-    void Update () {
+    void Update() {
         if (this._ready) {
             this.updateNPCWorldView();
             this.handleInstructions();
@@ -135,7 +130,7 @@ public class NPCManager : NetworkBehaviour {
                 NPCWorldView.setRunNPCThread(false);
                 this._deadNpcs.Clear();
                 this._deadPlayers.Clear();
-                this._ready = false;              
+                this._ready = false;
                 return;
             } else
                 if (this._npcThread.isUpdating) { this._npcThread.wait = true; return; /*Wait for npc thread to catch up */}
@@ -159,7 +154,6 @@ public class NPCManager : NetworkBehaviour {
     //Recieves instructions from the NPCThread, and passes them along to the NPC GameObjects in the scene
     void handleInstructions() {
         while (!this._instructions.isEmpty()) {
-            //Debug.Log("CHEECKY");
             var instruction = this._instructions.Dequeue();
             if (this._npcs.ContainsKey(instruction.id) && this._npcs[instruction.id] != null)
                 this._npcs[instruction.id].GetComponent<NPC>().update(instruction.moveDir, instruction.goal);
@@ -176,7 +170,7 @@ public class NPCManager : NetworkBehaviour {
             int x = Random.Range(0, this._cellCount);
             int y = Random.Range(0, this._cellCount);
             landCell = NPCWorldView.getCell(true, x, y);
-            waterCell = NPCWorldView.getCell(false, x, y);            
+            waterCell = NPCWorldView.getCell(false, x, y);
         } while (landCell.blocked || !waterCell.blocked);
 
         //Angle is used to generate a direction
@@ -185,7 +179,7 @@ public class NPCManager : NetworkBehaviour {
         npcInstance.GetComponent<NPC>().spawn(landCell.pos, dir);
 
         NetworkServer.Spawn(npcInstance);
-        
+
     }
 
     //It's important to stop the NPCThread when quitting

--- a/BunnyGame/Assets/Scripts/NPC/NPCThread.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCThread.cs
@@ -47,7 +47,6 @@ public class NPCThread {
             if (this._instructions.isEmpty() && !this._wait) {
                 this._isUpdating = true;
                 foreach (var npcBrain in this._npcBrains) {
-                    if (npcBrain._npc == null) Debug.Log("BRAIN HAS NULL NPC");
                     if (npcBrain.npcAlive())
                         npcBrain.update();
                     else

--- a/BunnyGame/Assets/Scripts/NPC/NPCThread.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCThread.cs
@@ -47,6 +47,7 @@ public class NPCThread {
             if (this._instructions.isEmpty() && !this._wait) {
                 this._isUpdating = true;
                 foreach (var npcBrain in this._npcBrains) {
+                    if (npcBrain._npc == null) Debug.Log("BRAIN HAS NULL NPC");
                     if (npcBrain.npcAlive())
                         npcBrain.update();
                     else

--- a/BunnyGame/Assets/Scripts/NPC/NPCWorldView.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCWorldView.cs
@@ -196,6 +196,17 @@ public static class NPCWorldView {
         initPlane(_land, _landOffset);
         initPlane(_water, _waterOffset);
     }
+
+    public static void clear() {
+        _runNPCThread = false;
+        _ready = false;
+
+        _npcs = null;
+        _players = null;
+
+        _land = null;
+        _water = null;
+    }
     //===============================================================================
     public static Vector3 landOffset { get { return _landOffset; } }
     public static Vector3 waterOffset { get { return _waterOffset; } }

--- a/BunnyGame/Assets/Scripts/NPC/NPCWorldViewManager.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCWorldViewManager.cs
@@ -190,6 +190,10 @@ public class NPCWorldViewManager : MonoBehaviour {
             closed.ElementAt(i).Value.blocked = true;
     }
 
+    private void OnDestroy() {
+        NPCWorldView.clear();
+    }
+
     void OnDrawGizmos() {
         if (debugRenderLand) {
             drawGizmo(true);

--- a/BunnyGame/Assets/Scripts/Server/ServerSetup.cs
+++ b/BunnyGame/Assets/Scripts/Server/ServerSetup.cs
@@ -11,6 +11,10 @@ public class ServerSetup : NetworkBehaviour {
             GameObject fireWall = Resources.Load<GameObject>("Prefabs/FireWall");
             fireWall = Instantiate(fireWall);
             NetworkServer.Spawn(fireWall);
+
+            GameObject npcManager = Resources.Load<GameObject>("Prefabs/NPCManager");
+            npcManager = Instantiate(npcManager);
+            NetworkServer.Spawn(npcManager);
         }
 	}
 }


### PR DESCRIPTION
The issue was caused due to Unity SyncVar optimization, when you spawn a network object, its SyncVars will keep the value they last had, if there are any. This made it so that the SyncVar would only get synced in the first game, so in games after the first game the SyncVar hook didn't get called, because its value didn't change on the server.

I've experience one issue after the fix, but i haven't been able to reproduce it.
The issue was: The NPCThread only sent one instruction then stopped.