### PR TITLE
Fixed screen effects being applied based on location of dead player

### DIFF
--- a/BunnyGame/Assets/Scenes/Island.unity
+++ b/BunnyGame/Assets/Scenes/Island.unity
@@ -309,12 +309,12 @@ Prefab:
     - target: {fileID: 224625647126962944, guid: 46fd08022e0481a4db71539919f7d1eb,
         type: 2}
       propertyPath: m_LocalPosition.x
-      value: 668
+      value: 568.5
       objectReference: {fileID: 0}
     - target: {fileID: 224625647126962944, guid: 46fd08022e0481a4db71539919f7d1eb,
         type: 2}
       propertyPath: m_LocalPosition.y
-      value: 339
+      value: 321.5
       objectReference: {fileID: 0}
     - target: {fileID: 224625647126962944, guid: 46fd08022e0481a4db71539919f7d1eb,
         type: 2}
@@ -857,7 +857,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 376393139}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 648, y: 259, z: 0}
+  m_LocalPosition: {x: 548.5, y: 241.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1353435133}
@@ -1447,7 +1447,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 530150810}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 416, y: -169.25, z: 0}
+  m_LocalPosition: {x: 341.375, y: -156.125, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1256685111}
@@ -1726,12 +1726,12 @@ Prefab:
     - target: {fileID: 224647576811944834, guid: 5a82466091efcfb47860fc93a946479c,
         type: 2}
       propertyPath: m_LocalPosition.x
-      value: 668
+      value: 568.5
       objectReference: {fileID: 0}
     - target: {fileID: 224647576811944834, guid: 5a82466091efcfb47860fc93a946479c,
         type: 2}
       propertyPath: m_LocalPosition.y
-      value: 339
+      value: 321.5
       objectReference: {fileID: 0}
     - target: {fileID: 224647576811944834, guid: 5a82466091efcfb47860fc93a946479c,
         type: 2}
@@ -2104,7 +2104,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 689247714}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 134.25, z: 0}
+  m_LocalPosition: {x: 0, y: 121.125, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1483854630}
@@ -2412,7 +2412,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 735544049}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 575.5, y: -94.2, z: 0}
+  m_LocalPosition: {x: 476, y: -94.2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 638441717}
@@ -2871,7 +2871,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 921211071}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -468, y: -189, z: 0}
+  m_LocalPosition: {x: -368.5, y: -171.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 37141592}
@@ -3967,7 +3967,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1353435129}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 668, y: 339, z: 0}
+  m_LocalPosition: {x: 568.5, y: 321.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1038108915}
@@ -4139,7 +4139,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1483854626}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 668, y: 339, z: 0}
+  m_LocalPosition: {x: 568.5, y: 321.5, z: 0}
   m_LocalScale: {x: 1.3333334, y: 1.3333334, z: 1.3333334}
   m_Children:
   - {fileID: 530150811}
@@ -5300,7 +5300,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1810361967}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 648, y: 324, z: 0}
+  m_LocalPosition: {x: 548.5, y: 306.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1353435133}
@@ -5393,7 +5393,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1843381381}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -249, z: 0}
+  m_LocalPosition: {x: 0, y: -231.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1082943965}
@@ -5831,7 +5831,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1942151578}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -254.25, z: 0}
+  m_LocalPosition: {x: 0, y: -241.125, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1483854630}
@@ -6208,12 +6208,12 @@ Prefab:
     - target: {fileID: 224179119851607162, guid: b7e67c082227a8944a47ad90efae0e89,
         type: 2}
       propertyPath: m_LocalPosition.x
-      value: 668
+      value: 568.5
       objectReference: {fileID: 0}
     - target: {fileID: 224179119851607162, guid: b7e67c082227a8944a47ad90efae0e89,
         type: 2}
       propertyPath: m_LocalPosition.y
-      value: 339
+      value: 321.5
       objectReference: {fileID: 0}
     - target: {fileID: 224179119851607162, guid: b7e67c082227a8944a47ad90efae0e89,
         type: 2}

--- a/BunnyGame/Assets/Scenes/Lobby.unity
+++ b/BunnyGame/Assets/Scenes/Lobby.unity
@@ -565,12 +565,12 @@ Prefab:
     - target: {fileID: 224504343465629732, guid: 7855c7e2a48e7c04fa48ac93a1718de3,
         type: 2}
       propertyPath: m_LocalPosition.x
-      value: 668
+      value: 568.5
       objectReference: {fileID: 0}
     - target: {fileID: 224504343465629732, guid: 7855c7e2a48e7c04fa48ac93a1718de3,
         type: 2}
       propertyPath: m_LocalPosition.y
-      value: 339
+      value: 321.5
       objectReference: {fileID: 0}
     - target: {fileID: 224504343465629732, guid: 7855c7e2a48e7c04fa48ac93a1718de3,
         type: 2}

--- a/BunnyGame/Assets/Scripts/Abilities/AbilityNetwork.cs
+++ b/BunnyGame/Assets/Scripts/Abilities/AbilityNetwork.cs
@@ -143,10 +143,10 @@ public class AbilityNetwork : NetworkBehaviour {
         StartCoroutine(GetComponent<BirdController>().flapLikeCrazy());
         var player = GameObject.FindGameObjectWithTag("Player");
         if (player.GetComponent<PlayerInformation>().ConnectionID != id) {
-            if (Vector3.Distance(player.transform.position, pos) < 20) {
+            if (Vector3.Distance(player.transform.position, pos) < 20 && !player.GetComponent<PlayerHealth>().IsDead()) {
                 StartCoroutine(player.GetComponent<PlayerEffects>().blind());
             }
-        }        
+        }
     }
 
 

--- a/BunnyGame/Assets/Scripts/Camera/ThirdPersonCamera.cs
+++ b/BunnyGame/Assets/Scripts/Camera/ThirdPersonCamera.cs
@@ -101,4 +101,9 @@ public class ThirdPersonCamera : MonoBehaviour {
     public Transform getTarget() {
         return _target;
     }
+
+    public string getTargetTag()
+    {
+        return _target.tag;
+    }
 }

--- a/BunnyGame/Assets/Scripts/FireWall/FireWall.cs
+++ b/BunnyGame/Assets/Scripts/FireWall/FireWall.cs
@@ -150,7 +150,6 @@ public class FireWall : NetworkBehaviour {
         if (!this._ready) return;
 
         if (other.tag == "Player") {
-            _outsideWallEffect.enabled = true;
             other.GetComponent<PlayerEffects>().insideWall = false;
         }else if (other.tag == "Enemy") {
             other.GetComponent<PlayerEffects>().insideWall = false;
@@ -159,16 +158,23 @@ public class FireWall : NetworkBehaviour {
         } else if (other.tag == "DustTornado") {
             other.GetComponent<DustTornado>().kill();
         }
+
+        if (other.tag == GameObject.Find("Main Camera").GetComponent<ThirdPersonCamera>().getTargetTag()) {
+            _outsideWallEffect.enabled = true;
+        }
     }
 
     void OnTriggerEnter(Collider other) {
         if (!this._ready) return;
 
         if (other.tag == "Player") {
-            _outsideWallEffect.enabled = false;
             other.GetComponent<PlayerEffects>().insideWall = true;
         } else if (other.tag == "Enemy") {
             other.GetComponent<PlayerEffects>().insideWall = true;
-        } 
+        }
+
+        if (other.tag == GameObject.Find("Main Camera").GetComponent<ThirdPersonCamera>().getTargetTag()) {
+            _outsideWallEffect.enabled = false;
+        }
     }
 }

--- a/BunnyGame/Assets/Scripts/Misc/Water.cs
+++ b/BunnyGame/Assets/Scripts/Misc/Water.cs
@@ -22,12 +22,12 @@ public class Water : MonoBehaviour {
             other.GetComponent<PlayerEffects>().onWaterStay(waterForce);
         }
 
-        if (other.tag == "Player")
+        if (other.tag == GameObject.Find("Main Camera").GetComponent<ThirdPersonCamera>().getTargetTag())
             waterScreenEffect.enabled = true; 
     }
 
     void OnTriggerExit(Collider other) {
-        if (other.tag == "Player")
+        if (other.tag == GameObject.Find("Main Camera").GetComponent<ThirdPersonCamera>().getTargetTag())
             waterScreenEffect.enabled = false;
     }
 }

--- a/BunnyGame/Assets/Scripts/Player/PlayerHealth.cs
+++ b/BunnyGame/Assets/Scripts/Player/PlayerHealth.cs
@@ -71,8 +71,10 @@ public class PlayerHealth : NetworkBehaviour {
 
     // Start spectating
     private void spectate() {
+        GameObject.Find("Main Camera").GetComponent<SpectatorController>().body = gameObject;
         GameObject.Find("Main Camera").GetComponent<SpectatorController>().startSpectating();
         GetComponent<PlayerController>().enabled = false;
+        GetComponent<Collider>().enabled = false;
         GetComponent<PlayerEffects>().enabled = false;
         for(int i = 0; i < transform.childCount; i++)
             transform.GetChild(i).gameObject.SetActive(false);

--- a/BunnyGame/Assets/Scripts/Player/PlayerHealth.cs
+++ b/BunnyGame/Assets/Scripts/Player/PlayerHealth.cs
@@ -71,7 +71,6 @@ public class PlayerHealth : NetworkBehaviour {
 
     // Start spectating
     private void spectate() {
-        GameObject.Find("Main Camera").GetComponent<SpectatorController>().body = gameObject;
         GameObject.Find("Main Camera").GetComponent<SpectatorController>().startSpectating();
         GetComponent<PlayerController>().enabled = false;
         GetComponent<Collider>().enabled = false;

--- a/BunnyGame/Assets/Scripts/Spectator/SpectatorController.cs
+++ b/BunnyGame/Assets/Scripts/Spectator/SpectatorController.cs
@@ -15,9 +15,6 @@ public class SpectatorController : MonoBehaviour {
     private SpectatorMode _spectatorMode;
     private SpectatorUI _ui;
 
-    public GameObject body;
-    
-
     private ThirdPersonCamera _thirdPersonCamera;
     private int _currentPlayerIdx = 0;
     public List<GameObject> _players = new List<GameObject>(); // Should contain only live players
@@ -64,9 +61,6 @@ public class SpectatorController : MonoBehaviour {
         // Switch spectating mode with Home-key
         if (Input.GetKeyDown(KeyCode.Home))
             setSpectatorMode((SpectatorMode)((int)~_spectatorMode & 1));
-
-        body.transform.position = this.transform.position;
-
 	}
 
     // This should be called when the players dies and wants to go into spectating mode
@@ -76,7 +70,6 @@ public class SpectatorController : MonoBehaviour {
         setSpectatorMode(SpectatorMode.FREE);
 
         _thirdPersonCamera.canFPS = false;
-        gameObject.tag = "Spectator";
 
         // Disable ui elements that aren't necessary to keep after going into spectate mode
         foreach (string str in "SpectateButton BloodSplatterOverlay AbilityPanel AttributeUI".Split(' '))

--- a/BunnyGame/Assets/Scripts/Spectator/SpectatorController.cs
+++ b/BunnyGame/Assets/Scripts/Spectator/SpectatorController.cs
@@ -14,6 +14,8 @@ public enum SpectatorMode
 public class SpectatorController : MonoBehaviour {
     private SpectatorMode _spectatorMode;
     private SpectatorUI _ui;
+
+    public GameObject body;
     
 
     private ThirdPersonCamera _thirdPersonCamera;
@@ -62,6 +64,9 @@ public class SpectatorController : MonoBehaviour {
         // Switch spectating mode with Home-key
         if (Input.GetKeyDown(KeyCode.Home))
             setSpectatorMode((SpectatorMode)((int)~_spectatorMode & 1));
+
+        body.transform.position = this.transform.position;
+
 	}
 
     // This should be called when the players dies and wants to go into spectating mode


### PR DESCRIPTION
Underwater and firewall effects are now based on the ThirdPersonCamera._target instead of the Player, so that it also works when spectating.

The dust storm effect is no longer applied to dead players.