### PR TITLE
Reworked how the AudioManager finds distance to water

### DIFF
--- a/BunnyGame/Assets/Scripts/AudioManager.cs
+++ b/BunnyGame/Assets/Scripts/AudioManager.cs
@@ -90,17 +90,12 @@ public class AudioManager : MonoBehaviour {
     // Sets the volume of the ocean sound based on distance from the ocean
     // also distorts sound when underwater
     private void updateOceanSound() {
-        float distFromCenter = Vector2.Distance(new Vector2(this.cameraTransform.position.x, this.cameraTransform.position.z), Vector2.zero);
-        float distFromOcean = findDistanceToWater();//mapRadius - distFromCenter;
-
+        float distFromOcean = findDistanceToWater();
 
         if (distFromOcean != -1) {
             _ocean.volume = (Mathf.Max((distFromOcean > 0 ? 3f / distFromOcean : 1f), .05f) / 2f) * effectVolume;
             _ocean.pitch = _isUnderWater ? 0.2f : 1f;
-            //Debug.Log("Current: " + distFromOcean + "; Old: " + (mapRadius - distFromCenter));
         }
-
-        // TODO : Surround/Stereo?
     }
 
 
@@ -118,9 +113,6 @@ public class AudioManager : MonoBehaviour {
         float distFromWall = Mathf.Abs(_firewall.transform.localScale.x / 2 - distFromCenter);
 
         _fire.volume = (distFromWall > 0 ? 0.05f + 0.95f * Mathf.Pow(1 - distFromWall / 250, 4) : 1) / 3 * effectVolume;
-
-
-        // TODO : Surround/Stereo?
     }
 
 
@@ -167,9 +159,9 @@ public class AudioManager : MonoBehaviour {
         }
 
         Vector3 closest_vec3 = NPCWorldView.convertWaterCell2World((int)closest.x, (int)closest.y, waterLevel);
-        Debug.Log("CLOSEST:" + closest_vec3 + "    MYPOS:" + cameraTransform.position + "     DIST:"+ Vector3.Distance(cameraTransform.position, closest_vec3));
-        Debug.Log("CLOSEST:" + closest + "    MYPOS:" + playerCellPos + "     DIST:"+ Vector3.Distance(cameraTransform.position, closest_vec3));
-        return Vector3.Distance(cameraTransform.position, closest_vec3);
+        float tileCenterToCorner = Mathf.Sqrt(Mathf.Pow(NPCWorldView.cellSize, 2) * 2);
+        Debug.Log(Vector3.Distance(cameraTransform.position, closest_vec3) + "   ::   " + Mathf.Max(Vector3.Distance(cameraTransform.position, closest_vec3), tileCenterToCorner) * (1 / tileCenterToCorner));
+        return Mathf.Max(Vector3.Distance(cameraTransform.position, closest_vec3), tileCenterToCorner) * (1/ tileCenterToCorner);
     }
 
 }

--- a/BunnyGame/Assets/Scripts/AudioManager.cs
+++ b/BunnyGame/Assets/Scripts/AudioManager.cs
@@ -140,7 +140,7 @@ public class AudioManager : MonoBehaviour {
             return -1;
 
         NPCWorldView.worldCellData[,] waterCells = NPCWorldView.water; // Getting a map of the water from here because it should already be generated for the npcs anyways.
-        int[] playercell = NPCWorldView.convertWorld2WaterCell(cameraTransform.position);
+        int[] playercell = NPCWorldView.convertWorld2Cell(cameraTransform.position);
         Vector2 playerCellPos = new Vector2(playercell[0], playercell[1]);
         int count = 0;
 
@@ -158,7 +158,8 @@ public class AudioManager : MonoBehaviour {
             }
         }
 
-        Vector3 closest_vec3 = NPCWorldView.convertWaterCell2World((int)closest.x, (int)closest.y, waterLevel);
+        Vector3 closest_vec3 = waterCells[(int)closest.x, (int)closest.y].pos;
+        closest_vec3.y = waterLevel;
         float tileCenterToCorner = Mathf.Sqrt(Mathf.Pow(NPCWorldView.cellSize, 2) * 2);
         Debug.Log(Vector3.Distance(cameraTransform.position, closest_vec3) + "   ::   " + Mathf.Max(Vector3.Distance(cameraTransform.position, closest_vec3), tileCenterToCorner) * (1 / tileCenterToCorner));
         return Mathf.Max(Vector3.Distance(cameraTransform.position, closest_vec3), tileCenterToCorner) * (1/ tileCenterToCorner);

--- a/BunnyGame/Assets/Scripts/NPC/NPCWorldView.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCWorldView.cs
@@ -114,13 +114,13 @@ public static class NPCWorldView {
                 this._pos = pos;
                 this._goal = goal;
             }
-        }   
-        
+        }
+
         public Vector3 getPos() {
-            lock (this) 
+            lock (this)
                 return this._pos;
         }
-        
+
         public Vector3 getMapPos() {
             lock (this) {
                 int[] index = convertWorld2Cell(this._pos);
@@ -136,12 +136,12 @@ public static class NPCWorldView {
         }
 
         public Vector3 getDir() {
-            lock (this) 
+            lock (this)
                 return this._dir;
         }
 
         public int getId() {
-            lock (this) 
+            lock (this)
                 return this._id;
         }
 
@@ -154,9 +154,9 @@ public static class NPCWorldView {
     //===============================================================================
     public const int cellCount = 150;
     public const float worldSize = 400;
-    public const float cellSize = worldSize/cellCount;
+    public const float cellSize = worldSize / cellCount;
 
-    private static Dictionary<int,GameCharacter> _npcs;
+    private static Dictionary<int, GameCharacter> _npcs;
     private static Dictionary<int, GameCharacter> _players;
     private static FireWall.Circle _fireWall;
     private static bool _runNPCThread;
@@ -212,6 +212,7 @@ public static class NPCWorldView {
     public static Vector3 waterOffset { get { return _waterOffset; } }
     public static bool ready { get { return _ready; } set { _ready = value; } }
     public static FireWall.Circle FireWall { get { return _fireWall; } set { _fireWall = value; } }
+    public static worldCellData[,] water { get { return _water; } }
     //===============================================================================
     public static void resetAStarData() {
         for (int y = 0; y < cellCount; y++) {
@@ -235,6 +236,31 @@ public static class NPCWorldView {
         cellPos[1] = clamp((int)world.z);
 
         return cellPos;
+    }
+
+    public static int[] convertWorld2WaterCell(Vector3 world)
+    {
+        int[] cellPos = { 0, 0 };
+        world -= waterOffset;
+        world /= cellSize;
+
+        cellPos[0] = clamp((int)world.x);
+        cellPos[1] = clamp((int)world.z);
+
+        return cellPos;
+    }
+
+    public static Vector3 convertWaterCell2World(int cellX, int cellZ, float waterLevel = 0)
+    {
+        Vector3 res = new Vector3(cellX + 0.5f, waterLevel, cellZ + 0.5f);
+
+        res.x *= cellSize;
+        res.z *= cellSize;
+
+        res.x += waterOffset.x;// + cellSize/2;
+        res.z += waterOffset.z;// + cellSize/2;
+
+        return res;
     }
 
     // No convenient way of using get; set; or overloading [,] operator that i found

--- a/BunnyGame/Assets/Scripts/NPC/NPCWorldView.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCWorldView.cs
@@ -238,30 +238,7 @@ public static class NPCWorldView {
         return cellPos;
     }
 
-    public static int[] convertWorld2WaterCell(Vector3 world)
-    {
-        int[] cellPos = { 0, 0 };
-        world -= waterOffset;
-        world /= cellSize;
 
-        cellPos[0] = clamp((int)world.x);
-        cellPos[1] = clamp((int)world.z);
-
-        return cellPos;
-    }
-
-    public static Vector3 convertWaterCell2World(int cellX, int cellZ, float waterLevel = 0)
-    {
-        Vector3 res = new Vector3(cellX + 0.5f, waterLevel, cellZ + 0.5f);
-
-        res.x *= cellSize;
-        res.z *= cellSize;
-
-        res.x += waterOffset.x;// + cellSize/2;
-        res.z += waterOffset.z;// + cellSize/2;
-
-        return res;
-    }
 
     // No convenient way of using get; set; or overloading [,] operator that i found
     //========================================================================================


### PR DESCRIPTION
How distance from water was found previously:
    ```islandRadius - vec3.distance(player, islandCenter)```

This new implementation makes use of the NPCWorldViews map of the water, by finding the closest cell and the distance from that to the players physical location.

I figured it might be a good idea to do this, incase we decide to add a map that isn't just a single circular island.