### PR TITLE
More destructive firewall 

### DIFF
--- a/BunnyGame/Assets/Resources/Materials.meta
+++ b/BunnyGame/Assets/Resources/Materials.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 4d15df4c1a2ff9447997fae08eab8f73
+folderAsset: yes
+timeCreated: 1509546684
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BunnyGame/Assets/Resources/Materials/Burned.mat
+++ b/BunnyGame/Assets/Resources/Materials/Burned.mat
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Burned
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.27205884, g: 0.27205884, b: 0.27205884, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/BunnyGame/Assets/Resources/Materials/Burned.mat.meta
+++ b/BunnyGame/Assets/Resources/Materials/Burned.mat.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: f0ac1c9b0768c6b4ebbef0af1fafe969
+timeCreated: 1509546519
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BunnyGame/Assets/Resources/Prefabs/FireWall.prefab
+++ b/BunnyGame/Assets/Resources/Prefabs/FireWall.prefab
@@ -24,6 +24,7 @@ GameObject:
   - component: {fileID: 136312354876455210}
   - component: {fileID: 114335696100584890}
   - component: {fileID: 114041595877771642}
+  - component: {fileID: 54418731510513906}
   m_Layer: 17
   m_Name: FireWall
   m_TagString: FireWall
@@ -85,6 +86,21 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1821135780120678}
   m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!54 &54418731510513906
+Rigidbody:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1821135780120678}
+  serializedVersion: 2
+  m_Mass: 0.0000001
+  m_Drag: 0
+  m_AngularDrag: 0
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 1
 --- !u!114 &114041595877771642
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/BunnyGame/Assets/Scenes/Lobby.unity
+++ b/BunnyGame/Assets/Scenes/Lobby.unity
@@ -565,12 +565,12 @@ Prefab:
     - target: {fileID: 224504343465629732, guid: 7855c7e2a48e7c04fa48ac93a1718de3,
         type: 2}
       propertyPath: m_LocalPosition.x
-      value: 568.5
+      value: 891
       objectReference: {fileID: 0}
     - target: {fileID: 224504343465629732, guid: 7855c7e2a48e7c04fa48ac93a1718de3,
         type: 2}
       propertyPath: m_LocalPosition.y
-      value: 321.5
+      value: 449
       objectReference: {fileID: 0}
     - target: {fileID: 224504343465629732, guid: 7855c7e2a48e7c04fa48ac93a1718de3,
         type: 2}

--- a/BunnyGame/Assets/Scripts/AudioManager.cs
+++ b/BunnyGame/Assets/Scripts/AudioManager.cs
@@ -138,4 +138,33 @@ public class AudioManager : MonoBehaviour {
             player.GetComponent<PlayerAudio>().updateVolume(effectVolume);
     }
 
+    private float findDistanceToWater() {
+        if (!NPCWorldView.ready)
+            return -1;
+
+        NPCWorldView.worldCellData[,] waterCells = NPCWorldView.water; // Getting a map of the water from here because it should already be generated for the npcs anyways.
+        int[] playercell = NPCWorldView.convertWorld2Cell(cameraTransform.position);
+        Vector2 playerCellPos = new Vector2(playercell[0], playercell[1]);
+        int count = 0;
+
+        Vector2 closest = new Vector2(500, 500);
+        for (int x = 0; x < waterCells.GetLength(0); x++) {
+            for (int z = 0; z < waterCells.GetLength(1); z++) {
+                if (!waterCells[x, z].blocked) {
+                    if(Vector2.Distance(playerCellPos, new Vector2(x, z)) < 
+                       Vector2.Distance(playerCellPos, closest)) {
+                        closest.x = x;
+                        closest.y = z;
+                        count++;
+                    }
+                }
+            }
+        }
+
+        Vector3 closest_vec3 = waterCells[(int)closest.x, (int)closest.y].pos;
+        closest_vec3.y = waterLevel;
+        float tileCenterToCorner = Mathf.Sqrt(Mathf.Pow(NPCWorldView.cellSize, 2) * 2);
+        //Debug.Log(Vector3.Distance(cameraTransform.position, closest_vec3) + "   ::   " + Mathf.Max(Vector3.Distance(cameraTransform.position, closest_vec3), tileCenterToCorner) * (1 / tileCenterToCorner));
+        return Mathf.Max(Vector3.Distance(cameraTransform.position, closest_vec3), tileCenterToCorner) * (1/ tileCenterToCorner);
+    }
 }

--- a/BunnyGame/Assets/Scripts/AudioManager.cs
+++ b/BunnyGame/Assets/Scripts/AudioManager.cs
@@ -161,7 +161,7 @@ public class AudioManager : MonoBehaviour {
         Vector3 closest_vec3 = waterCells[(int)closest.x, (int)closest.y].pos;
         closest_vec3.y = waterLevel;
         float tileCenterToCorner = Mathf.Sqrt(Mathf.Pow(NPCWorldView.cellSize, 2) * 2);
-        Debug.Log(Vector3.Distance(cameraTransform.position, closest_vec3) + "   ::   " + Mathf.Max(Vector3.Distance(cameraTransform.position, closest_vec3), tileCenterToCorner) * (1 / tileCenterToCorner));
+        //Debug.Log(Vector3.Distance(cameraTransform.position, closest_vec3) + "   ::   " + Mathf.Max(Vector3.Distance(cameraTransform.position, closest_vec3), tileCenterToCorner) * (1 / tileCenterToCorner));
         return Mathf.Max(Vector3.Distance(cameraTransform.position, closest_vec3), tileCenterToCorner) * (1/ tileCenterToCorner);
     }
 

--- a/BunnyGame/Assets/Scripts/FireWall/FireWall.cs
+++ b/BunnyGame/Assets/Scripts/FireWall/FireWall.cs
@@ -41,7 +41,7 @@ public class FireWall : NetworkBehaviour {
         }
     }
  
-    private const float _wallShrinkTime = 60.0f;//Time in seconds between _wall shrinking
+    private const float _wallShrinkTime = 10.0f;//Time in seconds between _wall shrinking
     private const float _wallShrinkRate = 0.04f; //The rate at which the wall shrinks
 
     private WallMapRenderer _actualWallRenderer;//Renders the actual fire wall
@@ -50,6 +50,8 @@ public class FireWall : NetworkBehaviour {
     private Image           _outsideWallEffect; //A red transparent UI panel indicating that the player is outside the wall
     private Circle          _current;           //The current circle
     private Circle          _target;            //The target circle
+    private Material        _burned;            //The material used for burned stuff
+    private GameObject      _fire;              //Particle effect for fire
     private System.Random   _RNG;               //Number generator, will be seeded the same across all clients
     [SyncVar(hook="init")]
     private int             _rngSeed;
@@ -58,6 +60,8 @@ public class FireWall : NetworkBehaviour {
     private bool            _ready = false;     //Wall ready
 
     void Start() {
+        _burned = Resources.Load<Material>("Materials/Burned");
+        this._fire = Resources.Load<GameObject>("Prefabs/Fire");
         if (this.isServer) StartCoroutine(waitForClients());
     }
 
@@ -110,6 +114,11 @@ public class FireWall : NetworkBehaviour {
         this._actualWallRenderer.draw(this.transform);
     }   
 
+    private void spawnFire() {
+        float lowerRadius = this._current.radius;
+
+    }
+
     private void UpdateWallUI() {
         _wallTransitionUI.sizeDelta = new Vector2(150 * this._wallShrinkTimer / _wallShrinkTime, 10);
     }
@@ -148,7 +157,7 @@ public class FireWall : NetworkBehaviour {
 
     void OnTriggerExit(Collider other) {
         if (!this._ready) return;
-
+        Debug.Log(other.tag);
         if (other.tag == "Player") {
             other.GetComponent<PlayerEffects>().insideWall = false;
         }else if (other.tag == "Enemy") {
@@ -157,6 +166,13 @@ public class FireWall : NetworkBehaviour {
             other.GetComponent<NPC>().burn();
         } else if (other.tag == "DustTornado") {
             other.GetComponent<DustTornado>().kill();
+        } else if (other.tag == "ground") {
+            var renderer = other.GetComponent<MeshRenderer>();
+            Debug.Log(renderer.material.name);
+            if (renderer.material.name.Contains("mat10")
+                || renderer.material.name.Contains("mat12")
+                || renderer.material.name.Contains("mat20"))
+                renderer.material = _burned;
         }
 
         if (other.tag == GameObject.Find("Main Camera").GetComponent<ThirdPersonCamera>().getTargetTag()) {

--- a/BunnyGame/Assets/Scripts/Misc/AddCollider.cs
+++ b/BunnyGame/Assets/Scripts/Misc/AddCollider.cs
@@ -7,6 +7,7 @@ public class AddCollider : MonoBehaviour {
 	void Awake () {
         foreach (Transform t in transform) {
             t.gameObject.AddComponent<MeshCollider>();
+            //t.transform.parent = transform.parent;
         }
     }
 }

--- a/BunnyGame/Assets/Scripts/NPC/NPCWorldView.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCWorldView.cs
@@ -212,6 +212,7 @@ public static class NPCWorldView {
     public static Vector3 waterOffset { get { return _waterOffset; } }
     public static bool ready { get { return _ready; } set { _ready = value; } }
     public static FireWall.Circle FireWall { get { return _fireWall; } set { _fireWall = value; } }
+    public static worldCellData[,] water { get { return _water;  } }
     //===============================================================================
     public static void resetAStarData() {
         for (int y = 0; y < cellCount; y++) {

--- a/BunnyGame/Assets/Scripts/Player/PlayerController.cs
+++ b/BunnyGame/Assets/Scripts/Player/PlayerController.cs
@@ -181,14 +181,14 @@ public class PlayerController : NetworkBehaviour {
     }
 
     private bool onWall() {
-        const float deltaLimit = 1.00f;
+        const float deltaLimit = 1.6f;
         Vector3[] offsets = { Vector3.forward, Vector3.back, Vector3.left, Vector3.right };
 
         float[] distances = new float[offsets.Length];
         RaycastHit hit = new RaycastHit();
 
         for (int i = 0; i < offsets.Length; i++) {
-            Physics.Raycast(transform.position + offsets[i], Vector3.down, out hit);
+            Physics.Raycast(transform.position + offsets[i] + Vector3.up, Vector3.down, out hit);
             distances[i] = hit.distance;
         }
 


### PR DESCRIPTION
- Firewall now gives parts of the island that i touches a black material, to make them look burned.
- Fire now spawns outside the fire wall all the time to make it look more destructive.
- Relaxed onWall() to make jumping easier.

The entire object needs to be outside the firewall for OnTriggerExit() to trigger, so this will look weird for some objects. OnTriggerEnter() won't work, because it triggers for every object inside the firewall, which is everything.