### PR TITLE
Fix: Firewall and projectiles not ignored by the camera collision (#129 and #141)

### DIFF
--- a/BunnyGame/Assets/Scripts/Bunny/BunnyPoop.cs
+++ b/BunnyGame/Assets/Scripts/Bunny/BunnyPoop.cs
@@ -41,7 +41,7 @@ public class BunnyPoop : NetworkBehaviour {
     }
 
     private void OnCollisionEnter(Collision other) {
-        if (other.gameObject.tag != "Player")
+        if (other.gameObject.tag != "Player" && other.gameObject.tag != "MainCamera")
             NetworkServer.Destroy(this.gameObject);
     }
 

--- a/BunnyGame/Assets/Scripts/Camera/ThirdPersonCamera.cs
+++ b/BunnyGame/Assets/Scripts/Camera/ThirdPersonCamera.cs
@@ -85,7 +85,10 @@ public class ThirdPersonCamera : MonoBehaviour {
         RaycastHit hit;
         Ray ray = new Ray(this._target.transform.position, this.transform.position - this._target.transform.position);
         int layermask = (1 << 8);
+        layermask |= (1 << 9);
+        layermask |= (1 << 10);
         layermask |= (1 << 11);
+        layermask |= (1 << 17);
         layermask = ~layermask;
 
         if (Physics.Raycast(ray, out hit, this._distanceFromTarget, layermask)) {

--- a/BunnyGame/Assets/Scripts/Player/PlayerAttack.cs
+++ b/BunnyGame/Assets/Scripts/Player/PlayerAttack.cs
@@ -16,7 +16,7 @@ public class PlayerAttack : NetworkBehaviour {
 
         // PLAYER VS. ENEMY
         if (other.gameObject.tag == "Enemy") {
-            if ((attackerID < 0) || (victimID < 0) || (victimHealth == null))
+            if ((attackerID < 0) || (victimID < 0) || (victimHealth == null) || !other.transform.GetChild(1).gameObject.activeInHierarchy)
                 return;
 
             // BIRD


### PR DESCRIPTION
Added the firewall and projectile layers to the layermask in ThirdPersonCamera.cs:cameraCollision