### PR TITLE
Fixed issue #154 - Moose cannot kill fox

### DIFF
--- a/BunnyGame/Assets/Scripts/Player/PlayerHealth.cs
+++ b/BunnyGame/Assets/Scripts/Player/PlayerHealth.cs
@@ -377,11 +377,11 @@ public class PlayerHealth : NetworkBehaviour {
 
     // Update the health/damage screen overlay.
     private void updateDamageScreen(float damageAmount) {
-        if (!this.isLocalPlayer || (this._damageImage == null) || (this._damageImage.color.a >= 1.0f) || (this._currentHealth < 0))
+        if (!this.isLocalPlayer || (this._damageImage == null) || (this._damageImage.color.a >= 1.0f) || this._isDead)
             return;
 
         this._currentHealth -= damageAmount;
-        this._isDead         = (this._currentHealth <= 0);
+        this._isDead         = (this._currentHealth < 1.0f);
 
         float alpha             = (1.0f - this._currentHealth / MAX_HEALTH);
         this._damageImage.color = new Color(this._damageImage.color.r, this._damageImage.color.g, this._damageImage.color.b, alpha);


### PR DESCRIPTION
The problem was due to floating point precision never reaching 0, fixed it by saying the player is dead if the value is less than 1.0f.