### PR TITLE
NPC sync scaling.

### DIFF
--- a/BunnyGame/Assets/Materials/BunnyAlert.mat
+++ b/BunnyGame/Assets/Materials/BunnyAlert.mat
@@ -72,5 +72,5 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 0.017829243}
+    - _Color: {r: 1, g: 1, b: 1, a: 0.01189369}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/BunnyGame/Assets/Materials/BunnyAlert.mat
+++ b/BunnyGame/Assets/Materials/BunnyAlert.mat
@@ -72,5 +72,5 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 0.017355714}
+    - _Color: {r: 1, g: 1, b: 1, a: 0.03518441}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/BunnyGame/Assets/Materials/BunnyAlert.mat
+++ b/BunnyGame/Assets/Materials/BunnyAlert.mat
@@ -72,5 +72,5 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 0.03518441}
+    - _Color: {r: 1, g: 1, b: 1, a: 0.017829243}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/BunnyGame/Assets/Materials/BunnyAlert.mat
+++ b/BunnyGame/Assets/Materials/BunnyAlert.mat
@@ -72,5 +72,5 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 0.01189369}
+    - _Color: {r: 1, g: 1, b: 1, a: 0.0067262948}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/BunnyGame/Assets/Scripts/NPC/NPC.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPC.cs
@@ -14,9 +14,18 @@ public class NPC : NetworkBehaviour {
     [SyncVar(hook = "updateGoal")]
     private Vector3 _masterGoal;
 
-    private const float         _gravity = -12;
-    private const float         _syncRate = 1; //How many times to sync per second
+    private const float         _gravity = -12;   
 
+    //The NPCs will sync at different rates, but the total syncs per second for all NPCs is 
+    // 1 sync per second per npc.
+    //Sync factor gives npcs a sync priority, so NPCs with a higher sync factor
+    // will get more of the total syncs per second then npcs with a low syncfactor.
+    //NPCs that are closer to players get a higher sync factor.
+    private static float        _totalSyncFactor = 0; 
+    private static int          _npcCount = 0;
+    private float               _oldSyncFactor = 0;
+    private float               _syncFactor = 1;
+    private float               _syncRate = 1; //How many times to sync per second   
     private float               _syncTimer;
     private Vector3             _moveDir;
     private Vector3             _goal; //Used by the brain, need it here for syncing
@@ -24,6 +33,8 @@ public class NPC : NetworkBehaviour {
     private GameObject          _blood;
     private GameObject          _fire;
     private float               _yVel;
+    private int                 _syncFrame = 0;     //Which frame should this npc do syncing? (Used to distribute the load)
+    private int                 _syncCounter = 0;   //Counting frames
 
     private Animator _ani;
 
@@ -38,8 +49,12 @@ public class NPC : NetworkBehaviour {
         this._ani   = GetComponentInChildren<Animator>();
 
         this.IsDead = false;
+        _npcCount++;
 
-        if (this.isServer) { this._syncTimer = 0; this.syncClients(); }
+        if (this.isServer) {
+            this._syncTimer = 0;
+            this.syncClients();
+        }
     }
 
     // Update is called once per frame
@@ -56,10 +71,14 @@ public class NPC : NetworkBehaviour {
 
         //sync clients
         if (this.isServer) {
-            this._syncTimer += Time.deltaTime;
-            if (this._syncTimer > _syncRate) {
-                this.syncClients();
-                this._syncTimer = 0;
+            this._syncCounter++;
+            if (this._syncCounter % this._syncFrame == 0) {
+                calcSyncRate();
+                this._syncTimer += Time.deltaTime;
+                if (this._syncTimer > _syncRate) {
+                    this.syncClients();
+                    this._syncTimer = 0;
+                }
             }
         }
     }
@@ -77,12 +96,32 @@ public class NPC : NetworkBehaviour {
         die();
     }
 
-    public void spawn(Vector3 pos, Vector3 dir) {
+    public void spawn(Vector3 pos, Vector3 dir, int frame = 0) {
+        this._syncFrame = frame;
         IsDead = false;
         pos.y += 20;
         this.transform.position = pos;
         this._moveDir = dir;
         this.syncClients();
+    }
+
+    private void calcSyncRate() {
+        this._oldSyncFactor = this._syncFactor;
+        this._syncFactor = 0;
+        this._syncFactor = 400.0f / closestPlayer();
+        _totalSyncFactor = this._syncFactor - this._oldSyncFactor;
+        this._syncRate = _syncFactor * (_npcCount / _totalSyncFactor);
+    }
+
+    private float closestPlayer() {
+        float bestDist = 999999;
+        float dist = 999999;
+        var players = NPCWorldView.players;
+        foreach (var player in players.Values) {
+            dist = Vector3.Distance(transform.position, player.getPos());
+            if (dist < bestDist) bestDist = dist; 
+        }
+        return bestDist;
     }
 
     private void updateMasterPos(Vector3 masterPos) {
@@ -122,5 +161,9 @@ public class NPC : NetworkBehaviour {
         fire.transform.position = pos;
         NetworkServer.Spawn(fire);
         Destroy(fire, 10.0f);
+    }
+
+    private void OnDestroy() {
+        _npcCount--;
     }
 }

--- a/BunnyGame/Assets/Scripts/NPC/NPC.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPC.cs
@@ -24,7 +24,7 @@ public class NPC : NetworkBehaviour {
     private static float        _totalSyncFactor = 0; 
     private static int          _npcCount = 0;
     private float               _oldSyncFactor = 0;
-    private float               _syncFactor = 1;
+    private float               _syncFactor = 0;
     private float               _syncRate = 1; //How many times to sync per second   
     private float               _syncTimer;
     private Vector3             _moveDir;
@@ -91,6 +91,10 @@ public class NPC : NetworkBehaviour {
         return this._goal;
     }
 
+    public float getSyncRate() {
+        return this._syncRate;
+    }
+
     public void burn() {
         CmdBurn(this.transform.position);
         die();
@@ -107,9 +111,8 @@ public class NPC : NetworkBehaviour {
 
     private void calcSyncRate() {
         this._oldSyncFactor = this._syncFactor;
-        this._syncFactor = 0;
         this._syncFactor = 400.0f / closestPlayer();
-        _totalSyncFactor = this._syncFactor - this._oldSyncFactor;
+        _totalSyncFactor += this._syncFactor - this._oldSyncFactor;
         this._syncRate = _syncFactor * (_npcCount / _totalSyncFactor);
     }
 

--- a/BunnyGame/Assets/Scripts/NPC/NPC.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPC.cs
@@ -14,7 +14,8 @@ public class NPC : NetworkBehaviour {
     [SyncVar(hook = "updateGoal")]
     private Vector3 _masterGoal;
 
-    private const float         _gravity = -12;   
+    private const float         _gravity = -12;
+    private const float         _syncPerNPC = 0.8f;
 
     //The NPCs will sync at different rates, but the total syncs per second for all NPCs is 
     // 1 sync per second per npc.
@@ -113,7 +114,7 @@ public class NPC : NetworkBehaviour {
         this._oldSyncFactor = this._syncFactor;
         this._syncFactor = 400.0f / closestPlayer();
         _totalSyncFactor += this._syncFactor - this._oldSyncFactor;
-        this._syncRate = _syncFactor * (_npcCount / _totalSyncFactor);
+        this._syncRate = _syncFactor * ((_npcCount  * _syncPerNPC) / _totalSyncFactor);
     }
 
     private float closestPlayer() {

--- a/BunnyGame/Assets/Scripts/NPC/NPC.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPC.cs
@@ -72,7 +72,7 @@ public class NPC : NetworkBehaviour {
         //sync clients
         if (this.isServer) {
             this._syncCounter++;
-            if (this._syncCounter % this._syncFrame == 0) {
+            if ((this._syncCounter + this._syncFrame) % 5 == 0) {
                 calcSyncRate();
                 this._syncTimer += Time.deltaTime;
                 if (this._syncTimer > _syncRate) {

--- a/BunnyGame/Assets/Scripts/NPC/NPCBrain.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCBrain.cs
@@ -92,6 +92,11 @@ public class NPCBrain {
         }
     }
 
+    class start2end {
+        public WorldGrid.Cell start = new WorldGrid.Cell();
+        public WorldGrid.Cell end = new WorldGrid.Cell();
+    }
+
     //==============State classes==================================================
 
     //==============Roam state==================================================
@@ -132,8 +137,10 @@ public class NPCBrain {
     private class AvoidObstacle : State {
         protected Stack<WorldGrid.Cell> _path;
         protected Vector3 _goal;
+        protected start2end _oldPath;
         public AvoidObstacle(NPCBrain x) : base(x) {
             this._goal = Vector3.down;
+            this._oldPath = new start2end();
             this._path = new Stack<WorldGrid.Cell>();
             AStar(this._npc.getCellNoWater(), findTargetCell(x.npc.getDir()));
         }
@@ -206,6 +213,8 @@ public class NPCBrain {
 
         protected void AStar(WorldGrid.Cell startCell, WorldGrid.Cell goal) {
             if (goal == null || startCell == null) return;
+            if (_oldPath.start == startCell && _oldPath.end == goal) return;
+            this._oldPath.start = startCell; this._oldPath.end = goal;
 
             Dictionary<Vector3, WorldGrid.Cell> closed =
                 new Dictionary<Vector3, WorldGrid.Cell>();                                             //For quickly looking up closed nodes

--- a/BunnyGame/Assets/Scripts/NPC/NPCManager.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCManager.cs
@@ -95,17 +95,20 @@ public class NPCManager : NetworkBehaviour {
     //Updates data about players and npcs for NPCWorldView so that the NPCThread can use data about them
     private void updateNPCWorldView() {
         //Update NPCS
+        //float syncRate = 0;
         var npcs = NPCWorldView.npcs;
         foreach (var npc in this._npcs) {
             if (npc.Value != null && npc.Value.activeSelf) {
                 Vector3 goal = npc.Value.GetComponent<NPC>().getGoal();
                 npcs[npc.Key].update(npc.Value.transform.position, npc.Value.transform.forward, goal);
+                //syncRate += npc.Value.GetComponent<NPC>().getSyncRate();
             } else {
                 if (GameInfo.gamemode == "Battleroyale")
                     npcs[npc.Key].alive = false;
                 this._deadNpcs.Add(npc.Key);
             }
         }
+        //Debug.Log(syncRate); //This should equal NPC count;
         //Update Players
         var players = NPCWorldView.players;
         foreach (var player in this._players) {

--- a/BunnyGame/Assets/Scripts/NPC/NPCManager.cs
+++ b/BunnyGame/Assets/Scripts/NPC/NPCManager.cs
@@ -40,7 +40,7 @@ public class NPCManager : NetworkBehaviour {
         List<GameObject> npcs = new List<GameObject>();
         
         foreach (string name in npcPrefabNames) npcs.Add(Resources.Load<GameObject>("Prefabs/NPCs/" + name));
-        for (int i = 0; i < _npcCount; i++) this.CmdSpawnNPC(npcs[Random.Range(0, npcs.Count)]);
+        for (int i = 0; i < _npcCount; i++) this.CmdSpawnNPC(npcs[Random.Range(0, npcs.Count)], i % 5);
     }
 
     //Spawn NPCs, then register players/npcs in datastructures in this class, and NPCWorldView
@@ -193,7 +193,7 @@ public class NPCManager : NetworkBehaviour {
 
     //Spawns a NPC with a random direction
     [Command]
-    private void CmdSpawnNPC(GameObject npc) {
+    private void CmdSpawnNPC(GameObject npc, int syncFrame) {
         int y = (Random.Range(0.0f, 1.0f) < 0.3f) ? Random.Range(1, WorldData.yOffsets.Length) : 1;
 
         var npcInstance = Instantiate(npc);
@@ -202,7 +202,7 @@ public class NPCManager : NetworkBehaviour {
         float angle = Random.Range(0, Mathf.PI * 2);
         Vector3 dir = new Vector3(Mathf.Cos(angle), 0, Mathf.Sin(angle));
         //Spawn npc
-        npcInstance.GetComponent<NPC>().spawn(cell.pos, dir);
+        npcInstance.GetComponent<NPC>().spawn(cell.pos, dir, syncFrame);
         NetworkServer.Spawn(npcInstance);
     }
 

--- a/BunnyGame/Assets/Scripts/Portals/PortalManager.cs
+++ b/BunnyGame/Assets/Scripts/Portals/PortalManager.cs
@@ -50,6 +50,8 @@ public class PortalManager : NetworkBehaviour {
         while (!GameInfo.playersReady) //When this is true, all clients are connected and in the game scene
             yield return 0;
 
+        yield return new WaitForSeconds(0.5f);
+
         //Level 1 to 2 portals
         for (int level = 0; level < portalCounts.Length; level++) {
             for (int i = 0; i < portalCounts[level]; i++) {


### PR DESCRIPTION
NPCs should now sync more often if they are closer to players. Total collective NPC syncing should not increase tough, so whenever a npc gets close to a player and syncs more, distant NPCs start syncing less to offset the network traffic.